### PR TITLE
fix: Add support for specifying StorageClass, in case not using default

### DIFF
--- a/charts/cloud/Chart.yaml
+++ b/charts/cloud/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Protopie Cloud
 
 type: application
 
-version: 2.3.0
+version: 2.3.1
 
 appVersion: "13.0.3"

--- a/charts/cloud/templates/alb-ingress.yaml
+++ b/charts/cloud/templates/alb-ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -19,4 +22,11 @@ spec:
                 name: nginx
                 port:
                   number: 80
+
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName | default "protopie-tls" }}
+  {{- end }}
 {{- end }}

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -127,3 +127,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cloud.volumes.upload }}
+  {{- if .Values.cloud.storageClass }}
+  storageClassName: {{ .Values.cloud.storageClass }}
+  {{- end }}

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -127,6 +127,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cloud.volumes.upload }}
-  {{- if .Values.cloud.storageClass }}
-  storageClassName: {{ .Values.cloud.storageClass }}
+  {{- if .Values.cloud.volumes.storageClassName }}
+  storageClass: {{ .Values.cloud.volumes.storageClassName }}
   {{- end }}

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -128,5 +128,5 @@ spec:
     requests:
       storage: {{ .Values.cloud.volumes.upload }}
   {{- if .Values.cloud.volumes.storageClassName }}
-  storageClass: {{ .Values.cloud.volumes.storageClassName }}
+  storageClassName: {{ .Values.cloud.volumes.storageClassName }}
   {{- end }}

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -123,7 +123,7 @@ metadata:
   name: upload-enterprise-cloud-api
 spec:
   accessModes:
-  - ReadWriteMany
+  - {{ .Values.cloud.volumes.accessMode | default "ReadWriteMany" | quote }}
   resources:
     requests:
       storage: {{ .Values.cloud.volumes.upload }}

--- a/charts/cloud/templates/db-statefulset.yaml
+++ b/charts/cloud/templates/db-statefulset.yaml
@@ -59,6 +59,6 @@ spec:
       resources:
         requests:
           storage: {{ .Values.db.volume }}
-      {{- if .Values.db.storageClass }}
-      storageClassName: {{ .Values.db.storageClass }}
+      {{- if .Values.db.storageClassName }}
+      storageClass: {{ .Values.db.storageClassName }}
       {{- end }}

--- a/charts/cloud/templates/db-statefulset.yaml
+++ b/charts/cloud/templates/db-statefulset.yaml
@@ -59,3 +59,6 @@ spec:
       resources:
         requests:
           storage: {{ .Values.db.volume }}
+      {{- if .Values.db.storageClass }}
+      storageClassName: {{ .Values.db.storageClass }}
+      {{- end }}

--- a/charts/cloud/templates/db-statefulset.yaml
+++ b/charts/cloud/templates/db-statefulset.yaml
@@ -60,5 +60,5 @@ spec:
         requests:
           storage: {{ .Values.db.volume }}
       {{- if .Values.db.storageClassName }}
-      storageClass: {{ .Values.db.storageClassName }}
+      storageClassName: {{ .Values.db.storageClassName }}
       {{- end }}

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -76,7 +76,7 @@ cloud:
   volumes:
     upload: 50Gi
     # If left empty, the default storage class will be used
-    storageClass: ""
+  storageClass: ""
   config:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -76,7 +76,7 @@ cloud:
   volumes:
     upload: 50Gi
     # If left empty, the default storage class will be used
-  storageClass: ""
+    storageClassName: ""
   config:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:
@@ -94,7 +94,7 @@ nginx:
 db:
   volume: 20Gi
   # If left empty, the default storage class will be used
-  storageClass: ""
+  storageClassName: ""
   env:
     DB_HOST: db
     DB_PORT: 5432

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -75,6 +75,8 @@ cloud:
     replicas: 1
   volumes:
     upload: 50Gi
+    # If left empty, the default storage class will be used
+    storageClass: ""
   config:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:
@@ -91,6 +93,8 @@ nginx:
 
 db:
   volume: 20Gi
+  # If left empty, the default storage class will be used
+  storageClass: ""
   env:
     DB_HOST: db
     DB_PORT: 5432

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -27,9 +27,14 @@ image:
       tag: api-1.0.1
 
 ingress:
+  # If you want to use a specific ingress class, set the value here.
+  ingressClassName: ""
   enabled: false
   host: ""
   annotations: {}
+  # To enable certificate, set the value to true.
+  tls:
+    enabled: false
 
 # eg) for private docker image registry (imagePullSecrets)
 # imageCredentials:
@@ -77,6 +82,8 @@ cloud:
     upload: 50Gi
     # If left empty, the default storage class will be used
     storageClassName: ""
+    # Default accessMode is ReadWriteMany
+    accessMode: ""
   config:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:


### PR DESCRIPTION
Hello,

This PR suggests a change that allows specifying a Kubernetes `StorageClass` in case the user would rather use a non-default `StorageClass`.

- If user specifies `.Values.db.storageClass` as, for example, `databaseTier`, then the volume will be provisioned using the specified `storageClass`
- If `.Values.db/api.storageClass` is not specified, the functionality remains the same.

I hope you consider adding this functionality to the upstream Helm chart!