### PR TITLE
fix: Add support for specifying a certificate for the protopie ingress

### DIFF
--- a/charts/cloud/Chart.yaml
+++ b/charts/cloud/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Protopie Cloud
 
 type: application
 
-version: 2.3.0
+version: 2.3.1
 
 appVersion: "13.0.3"

--- a/charts/cloud/templates/alb-ingress.yaml
+++ b/charts/cloud/templates/alb-ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -19,4 +22,11 @@ spec:
                 name: nginx
                 port:
                   number: 80
+
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName | default "protopie-tls" }}
+  {{- end }}
 {{- end }}

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -27,9 +27,14 @@ image:
       tag: api-1.0.1
 
 ingress:
+  # If you want to use a specific ingress class, set the value here.
+  ingressClassName: ""
   enabled: false
   host: ""
   annotations: {}
+  # To enable certificate, set the value to true.
+  tls:
+    enabled: false
 
 # eg) for private docker image registry (imagePullSecrets)
 # imageCredentials:


### PR DESCRIPTION
This PR adds support for adding a certificate with `cert-manager` to the Protopie Helm chart. This functionality can be enabled in the `values.yml` with the following configuration:

```
ingress:
  # If you want to use a specific ingress class, set the value here.
  ingressClassName: "nginx"
  enabled: enabled
  host: "protopie.example.com"
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod

  # To enable certificate, set the value to true.
  tls:
    enabled: true
```

Resulting in an ingress resource: 

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: protopie-ingress
  labels:
    helm.sh/chart: cloud-2.3.1
    app.kubernetes.io/name: cloud
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "13.0.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-prod
spec:
  ingressClassName: nginx
  rules:
    - host: protopie.example.com
      http:
        paths:
          - pathType: Prefix
            path: "/"
            backend:
              service:
                name: nginx
                port:
                  number: 80
  tls:
    - hosts:
        - protopie.example.com
      secretName: protopie-tls
```

I hope you consider adding this to the upstream Helm chart :) 