### PR TITLE
fix: Add ReadWriteOnce support for API PVC to support EBS storage backend

### DIFF
--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -123,7 +123,7 @@ metadata:
   name: upload-enterprise-cloud-api
 spec:
   accessModes:
-  - ReadWriteMany
+  - {{ .Values.cloud.volumes.accessMode | default "ReadWriteMany" | quote }}
   resources:
     requests:
       storage: {{ .Values.cloud.volumes.upload }}

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -75,6 +75,8 @@ cloud:
     replicas: 1
   volumes:
     upload: 50Gi
+    # Default accessMode is ReadWriteMany
+    accessMode: ""
   config:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:


### PR DESCRIPTION
Hello, 

One more PR from me :D (There might be one more to support ArgoCD but more of that later)

We use EBS CSI driver in our platform. Unfortunately, volumes provisioned by the driver us AWS EBS as backend and they do not support `ReadWriteMany`.  This PR adds support to specify a different `accessMode`. 

As the API PVC is only used by the API `statefulSet` I think it's fine to allow `ReadWriteOnce` etc as the `accessMode` as well. 

Please consider this change again :) 