### PR TITLE
Updated Helm Chart for better compatibility

### DIFF
--- a/charts/cloud/Chart.yaml
+++ b/charts/cloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Protopie Cloud
 
 type: application
 
-version: 3.2.1
+version: 3.2.2
 
 appVersion: 15.7.0
 

--- a/charts/cloud/templates/_helpers.tpl
+++ b/charts/cloud/templates/_helpers.tpl
@@ -113,3 +113,15 @@ Generate Analytics DJANGO_SECRET_KEY - use provided value or generate random
 {{- randAlphaNum 50 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Lookup Cluster Domain
+*/}}
+{{- define "protopie.clusterDomain" -}}
+{{- $kubeSystem := lookup "v1" "ConfigMap" "kube-system" "kubelet-config" }}
+{{- if $kubeSystem }}
+{{- default .Values.clusterDomain (index $kubeSystem.data "clusterDomain") }}
+{{- else }}
+{{- .Values.clusterDomain }}
+{{- end }}
+{{- end }}

--- a/charts/cloud/templates/alb-ingress.yaml
+++ b/charts/cloud/templates/alb-ingress.yaml
@@ -12,7 +12,8 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
       http:
         paths:
           - pathType: Prefix
@@ -22,11 +23,14 @@ spec:
                 name: nginx
                 port:
                   number: 80
+    {{- end }}
 
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.ingress.host }}
+      {{- range $host := .Values.ingress.hosts }}
+        - {{ $host }}
+      {{- end }}
       secretName: {{ .Values.ingress.tls.secretName | default "protopie-tls" }}
   {{- end }}
 {{- end }}

--- a/charts/cloud/templates/analytics-api-deployment.yaml
+++ b/charts/cloud/templates/analytics-api-deployment.yaml
@@ -78,6 +78,8 @@ spec:
           httpGet:
             path: /
             port: http
+        resources:
+          {{- toYaml .Values.analytics.api.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/cloud/templates/analytics-web-deployment.yaml
+++ b/charts/cloud/templates/analytics-web-deployment.yaml
@@ -31,9 +31,9 @@ spec:
         imagePullPolicy: {{ .Values.image.analytics.web.pullPolicy }}
         env:
         - name: ANALYTICS_ENTERPRISE_API_URL
-          value: "http://ent-analytics-api-svc.{{ .Release.Namespace }}.svc.cluster.local"
+          value: "http://ent-analytics-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}"
         - name: ENTERPRISE_API_URL
-          value: "http://ent-cloud-api-svc.{{ .Release.Namespace }}.svc.cluster.local"
+          value: "http://ent-cloud-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}"
         - name: URL_BASE_PATHNAME
           value: {{ .Values.analytics.web.env.URL_BASE_PATHNAME }}
         - name: AE_API_USER_ID
@@ -51,6 +51,8 @@ spec:
         - name: http
           containerPort: 8050
           protocol: TCP
+        resources:
+          {{- toYaml .Values.analytics.web.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -94,7 +94,7 @@ spec:
               path: /
               port: http
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.cloud.api.resources | nindent 12 }}
           volumeMounts:
             - name: logs
               mountPath: /app/logs

--- a/charts/cloud/templates/db-secret.yaml
+++ b/charts/cloud/templates/db-secret.yaml
@@ -1,3 +1,5 @@
+{{- $dbSecret := lookup "v1" "Secret" .Release.Namespace "db-secret" }}
+{{- if not $dbSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,3 +19,4 @@ data:
   username: {{ .Values.db.env.POSTGRES_USER | b64enc | quote }}
   password: {{ .Values.db.env.POSTGRES_PASSWORD | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/cloud/templates/delete-download-files.yaml
+++ b/charts/cloud/templates/delete-download-files.yaml
@@ -49,7 +49,7 @@ metadata:
   labels:
     {{- include "protopie.labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.cloud.cleanUpSchedule | quote }}
+  schedule: {{ .Values.cloud.cleanup.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
@@ -62,8 +62,10 @@ spec:
           activeDeadlineSeconds: 300
           containers:
             - name: delete-download-files
-              image: bitnami/kubectl:1.28.2
+              image: {{ .Values.cloud.cleanup.image }}
               imagePullPolicy: IfNotPresent
+              resources:
+                {{- toYaml .Values.cloud.cleanup.resources | nindent 16 }}
               command:
                 - /bin/sh
                 - -c

--- a/charts/cloud/templates/nginx-deployment.yaml
+++ b/charts/cloud/templates/nginx-deployment.yaml
@@ -42,29 +42,29 @@ data:
 
   virtualhost.conf: |
     upstream web_server {
-      server ent-cloud-web-svc.{{ .Release.Namespace }}.svc.cluster.local;
+      server ent-cloud-web-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }};
     }
 
     {{- if .Values.userTesting.enabled }}
     upstream user-testing-api_server {
-      server ent-cloud-ut-svc.{{ .Release.Namespace }}.svc.cluster.local;
+      server ent-cloud-ut-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }};
     }
     upstream user-testing-socket_server {
-      server ent-cloud-ut-svc.{{ .Release.Namespace }}.svc.cluster.local:8081;
+      server ent-cloud-ut-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}:8081;
     }
     {{- end }}
 
     upstream api_server {
-      server ent-cloud-api-svc.{{ .Release.Namespace }}.svc.cluster.local;
+      server ent-cloud-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }};
     }
 
     {{- if .Values.analytics.enabled }}
     upstream analytics-web_server {
-      server ent-analytics-web-svc.{{ .Release.Namespace }}.svc.cluster.local;
+      server ent-analytics-web-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }};
     }
 
     upstream analytics-api_server {
-      server ent-analytics-api-svc.{{ .Release.Namespace }}.svc.cluster.local;
+      server ent-analytics-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }};
     }
     {{- end }}
 
@@ -280,6 +280,8 @@ spec:
           httpGet:
             path: /
             port: http
+        resources:
+          {{- toYaml .Values.nginx.resources | nindent 16 }}
         volumeMounts:
         - name: nginx-conf
           mountPath: /etc/nginx # mount nginx-conf volume to /etc/nginx

--- a/charts/cloud/templates/tests/test-connection.yaml
+++ b/charts/cloud/templates/tests/test-connection.yaml
@@ -13,6 +13,6 @@ spec:
       command: ['wget']
       args:
         - '-qO-'
-        - 'nginx.{{ .Release.Namespace }}.svc.cluster.local'
-        - 'ent-cloud-api-svc.{{ .Release.Namespace }}.svc.cluster.local'
+        - 'nginx.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}'
+        - 'ent-cloud-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}'
   restartPolicy: Never

--- a/charts/cloud/templates/user-testing-deployment.yaml
+++ b/charts/cloud/templates/user-testing-deployment.yaml
@@ -31,7 +31,7 @@ spec:
           imagePullPolicy: {{ .Values.image.cloud.userTesting.pullPolicy }}
           env:
             - name: API_URL
-              value: "http://ent-cloud-api-svc.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "http://ent-cloud-api-svc.{{ .Release.Namespace }}.svc.{{ include "protopie.clusterDomain" . }}"
             - name: HOST
               value: 0.0.0.0
             - name: SOCKETIO_HOST
@@ -45,12 +45,7 @@ spec:
             - name: logs
               mountPath: /app/logs
           resources:
-            requests:
-              cpu: "250m"
-              memory: "64Mi"
-            limits:
-              cpu: "1"
-              memory: "4Gi"
+            {{- toYaml .Values.userTesting.resources | nindent 16 }}
       volumes:
         - name: logs
           hostPath:

--- a/charts/cloud/templates/web-deployment.yaml
+++ b/charts/cloud/templates/web-deployment.yaml
@@ -25,5 +25,7 @@ spec:
         - name: ent-cloud-web
           image: "{{ .Values.image.cloud.web.repository }}:{{ .Values.image.cloud.web.tag }}"
           imagePullPolicy: {{ .Values.image.cloud.web.pullPolicy }}
+          resources:
+            {{- toYaml .Values.cloud.web.resources | nindent 12 }}
           ports:
             - containerPort: 3000

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -1,3 +1,4 @@
+clusterDomain: cluster.local
 nodeSelector: &nodeSelector {}
 podAnnotations:
   app: protopie
@@ -38,7 +39,8 @@ ingress:
   # If you want to use a specific ingress class, set the value here.
   ingressClassName: ""
   enabled: false
-  host: ""
+  hosts:
+  - protopie.local
   annotations: {}
   # To enable certificate, set the value to true.
   tls:
@@ -59,6 +61,7 @@ imagePullSecrets: null
 
 userTesting:
   enabled: false
+  resources: {}
 
 analytics:
   enabled: false
@@ -70,6 +73,7 @@ analytics:
       AE_API_USER_ID: "admin"
       # If left empty, a random password will be generated automatically
       AE_API_USER_PASS: ""
+    resources: {}
   api:
     env:
       ROOT_PATH: "/api/analytics/"
@@ -77,6 +81,7 @@ analytics:
       ALLOWED_HOSTS: "*"
       # If left empty, a random password will be generated automatically
       DJANGO_SECRET_KEY: ""
+    resources: {}
 
 cloud:
   host: ""
@@ -85,8 +90,10 @@ cloud:
     host: ""
   api:
     replicas: 1
+    resources: {}
   web:
     replicas: 1
+    resources: {}
   wellKnown:
     enabled: false
   volumes:
@@ -104,15 +111,18 @@ cloud:
     yml: "you can set content by --set-file cloud.config.yml=config.yml"
   license:
     pem: "you can set content by --set-file cloud.license.pem=license.pem"
-  # Europ/Berlin 5 AM - UTC 3 AM - 0 3 * * *
-  # America/NewYork 6 AM - UTC 10 AM - 0 10 * * *
-  # America/California 3 AM - UTC 10 AM - 0 10 * * *
-  # Asia/Mumbai 5 AM - UTC 11:30 PM - 30 11 * * *
-  # Asia/Seoul 5 AM - UTC 20 PM - 0 20 * * *
-  cleanUpSchedule: "* 20 * * *"
+  cleanup:
+    image: alpine/kubectl:1.34.2
+    schedule: "* 20 * * *"
+    # Europ/Berlin 5 AM - UTC 3 AM - 0 3 * * *
+    # America/NewYork 6 AM - UTC 10 AM - 0 10 * * *
+    # America/California 3 AM - UTC 10 AM - 0 10 * * *
+    # Asia/Mumbai 5 AM - UTC 11:30 PM - 30 11 * * *
+    # Asia/Seoul 5 AM - UTC 20 PM - 0 20 * * *
 
 nginx:
   replicas: 1
+  resources: {}
 
 db:
   volume: 20Gi


### PR DESCRIPTION
- Add resources to all containers
- Add helper for read clusterDomain 
- Detect DNS zone / set default in values.yaml 
- Check for existing DB secret (Postgres creates the permissions only on the first startup)
- Set Image for CleanUP Job over values (set default to alpine/kubectl:1.34.2)