### PR TITLE
chore(redis): bump user-testing redis to 8.6.3-alpine [PPIB-2929]

### DIFF
--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -27,7 +27,7 @@ image:
     userTestingRedis:
       pullPolicy: IfNotPresent
       repository: 310455165573.dkr.ecr.us-west-2.amazonaws.com/redis
-      tag: 8.2-alpine
+      tag: 8.6.3-alpine
   nginx:
     pullPolicy: IfNotPresent
     repository: nginx


### PR DESCRIPTION
## Summary
- `charts/cloud/values.yaml` `image.cloud.userTestingRedis.tag` 를 `8.2-alpine` → `8.6.3-alpine` 으로 변경 (1줄)
- ECR 미러: `310455165573.dkr.ecr.us-west-2.amazonaws.com/redis:8.6.3-alpine`

## Why
- 기존 `8.2-alpine` 에 redis-server CVE 3건 + openssl/zlib/musl CVE 다수 존재
- AWS Inspector 사전 검증 결과 `8.6.3-alpine` CRITICAL/HIGH 0건 (전체 severity 0건)

## Compatibility
- `command`: `redis-server --save 60 1000 --loglevel warning` — 무변경, upstream redis 8.x 호환
- `env`: 없음 — 영향 없음
- `mount`: `/data` (upstream redis 기본 경로) — 무변경
- 데이터 보존 불필요: Socket.IO broadcast/presence 캐시 용도, 파드 재시작 시 유실 허용 (emptyDir)

## Test plan
- [ ] staging-eks ArgoCD sync 후 `user-testing-redis` Pod `Running` 확인
- [ ] `kubectl exec` 로 `redis-cli ping` → `PONG` 응답 확인
- [ ] user-testing-server 의 Socket.IO broadcast/presence 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)