### PR TITLE
feat(cloud): podAnnotations support for db StatefulSet (3.2.3)

### DIFF
--- a/charts/cloud/Chart.yaml
+++ b/charts/cloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Protopie Cloud
 
 type: application
 
-version: 3.2.2
+version: 3.2.3
 
 appVersion: 15.7.0
 

--- a/charts/cloud/templates/db-statefulset-upstream.yaml
+++ b/charts/cloud/templates/db-statefulset-upstream.yaml
@@ -11,6 +11,10 @@ spec:
       app: db
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: db
     spec:

--- a/charts/cloud/templates/db-statefulset.yaml
+++ b/charts/cloud/templates/db-statefulset.yaml
@@ -11,6 +11,10 @@ spec:
       app:  db
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app:  db
     spec:


### PR DESCRIPTION
## Context

`api-statefulset.yaml` already supports `.Values.podAnnotations` for pod-level annotations on `enterprise-cloud-api` pods. `db-statefulset.yaml` and `db-statefulset-upstream.yaml` 동일 패턴 누락 — 같은 values key로 db pod에도 어노테이션 부여 가능하게 통일.

## Use case

staging-eks에서 Karpenter consolidation으로부터 db pod 보호:

```yaml
# cloud.values.yaml (다음 PR)
podAnnotations:
  karpenter.sh/do-not-disrupt: "true"
```

이 한 줄로 `enterprise-cloud-api` + `db` 둘 다 pod-level disrupt 차단 → -ee StatefulSet의 노드가 Karpenter에 의해 자발적으로 종료되지 않음. PPIB-3146 follow-up.

## Verification

```bash
helm template test charts/cloud \
  --set podAnnotations."karpenter\.sh/do-not-disrupt"=true \
  --set image.db.flavor=bitnami | grep -A 5 'name:  db'
```
→ db pod template에 어노테이션 잘 렌더링.

## Version

`3.2.2` → `3.2.3` bump.

## Target branch

`internal` (staging-eks가 직접 commit hash로 참조하는 브랜치). main은 enterprise-eks customer 환경용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)