### PR TITLE
fix(cloud): grant USAGE/CREATE on schema public to DB users (PG15+)

### DIFF
--- a/charts/cloud/templates/db-configmap.yaml
+++ b/charts/cloud/templates/db-configmap.yaml
@@ -32,6 +32,11 @@ data:
     psql -v ON_ERROR_STOP=1 --username "{{ .Values.db.env.POSTGRES_USER }}" --dbname "{{ .Values.db.env.DB_DATABASE }}" <<-EOSQL
       CREATE EXTENSION IF NOT EXISTS pgcrypto;
       CREATE EXTENSION IF NOT EXISTS pg_trgm;
+      -- PostgreSQL 15+ revokes default CREATE on schema public for non-superusers.
+      -- Without these GRANTs, the application user gets "permission denied for
+      -- schema public" the first time it tries to create a migration table.
+      GRANT USAGE, CREATE ON SCHEMA public TO {{ .Values.db.env.DB_WRITE_USER }};
+      GRANT USAGE ON SCHEMA public TO {{ .Values.db.env.DB_READ_USER }};
       ALTER DEFAULT PRIVILEGES FOR ROLE {{ .Values.db.env.DB_WRITE_USER }} IN SCHEMA public GRANT SELECT ON TABLES TO {{ .Values.db.env.DB_READ_USER }};
     EOSQL
 


### PR DESCRIPTION
## 문제

PostgreSQL 15+ revokes the default CREATE privilege on the `public` schema for non-superusers. 차트의 `02-role.sh`는 USER/EXTENSION 생성과 default privilege만 설정하고 schema-level GRANT은 누락 → 앱 user가 첫 migration 시:

```
PSQLException: ERROR: permission denied for schema public
```

## 발견 경위

staging-eks PPIB-3146 마이그레이션 후 `cilium-ee/enterprise-cloud-api-0` CrashLoopBackOff. `ragtime.jdbc/ensure-migrations-table-exists`에서 위 에러 확인. PostgreSQL 17.3 (PG15+) 사용 중.

## Fix

`02-role.sh`에 명시적 GRANT 추가:

```sql
GRANT USAGE, CREATE ON SCHEMA public TO DB_WRITE_USER;
GRANT USAGE ON SCHEMA public TO DB_READ_USER;
```

## 범위

- ✅ 새 install / fresh DB → init script이 실행되며 자동 적용
- ⚠️ 기존 라이브 DB → init script은 데이터 있으면 안 돌아감. 별도 manual GRANT 필요:
  ```sh
  kubectl --context stg-usw2 -n <ns> exec db-0 -- psql -U postgres -d <db> -c \
    "GRANT USAGE, CREATE ON SCHEMA public TO <write_user>; \
     GRANT USAGE ON SCHEMA public TO <read_user>;"
  ```

## 영향받을 환경

cilium-ee, clean-ee, dev-ee, engine-ee, f1-ee, f2-ee, f3-ee, f4-ee, h1-ee, qa-ee, onprem-ee, plus enterprise-eks의 모든 customer 환경 (chart 동일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)