### PR TITLE
feat(cloud): allow compute workloads to opt into spot capacity

### DIFF
--- a/charts/cloud/templates/_helpers.tpl
+++ b/charts/cloud/templates/_helpers.tpl
@@ -124,3 +124,24 @@ Generate Analytics DJANGO_SECRET_KEY - use provided value or generate random
 {{- randAlphaNum 50 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Compute-tier scheduling (nodeSelector / affinity / tolerations) for stateless
+workloads. Reads .Values.compute.* and falls back to the top-level values when
+unset, so existing consumers are unaffected. DB/stateful workloads keep using the
+top-level .Values.nodeSelector directly and are NOT steered by this helper.
+*/}}
+{{- define "cloud.computeScheduling" -}}
+{{- with (.Values.compute.nodeSelector | default .Values.nodeSelector) }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with (.Values.compute.affinity | default .Values.affinity) }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with (.Values.compute.tolerations | default .Values.tolerations) }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/cloud/templates/analytics-api-deployment.yaml
+++ b/charts/cloud/templates/analytics-api-deployment.yaml
@@ -14,10 +14,7 @@ spec:
       labels:
         app: ent-analytics-api
     spec:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.imagePullSecrets | toYaml | nindent 8 }}

--- a/charts/cloud/templates/analytics-web-deployment.yaml
+++ b/charts/cloud/templates/analytics-web-deployment.yaml
@@ -14,10 +14,7 @@ spec:
       labels:
         app: ent-analytics-web
     spec:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.imagePullSecrets | toYaml | nindent 8 }}

--- a/charts/cloud/templates/api-statefulset.yaml
+++ b/charts/cloud/templates/api-statefulset.yaml
@@ -114,18 +114,7 @@ spec:
               mountPath: /app/default
             - name: config
               mountPath: /app/resources
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       volumes:
         {{- if .Values.cloud.volumes.usePVC }}
         - name: logs

--- a/charts/cloud/templates/nginx-deployment.yaml
+++ b/charts/cloud/templates/nginx-deployment.yaml
@@ -327,10 +327,7 @@ spec:
         {{- end }}
         - name: log
           mountPath: /var/log/nginx
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       volumes:
       - name: nginx-conf
         configMap:

--- a/charts/cloud/templates/user-testing-deployment.yaml
+++ b/charts/cloud/templates/user-testing-deployment.yaml
@@ -14,10 +14,7 @@ spec:
       labels:
         app: ent-cloud-ut
     spec:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.imagePullSecrets | toYaml | nindent 8 }}

--- a/charts/cloud/templates/user-testing-redis-deployment.yaml
+++ b/charts/cloud/templates/user-testing-redis-deployment.yaml
@@ -16,10 +16,7 @@ spec:
       labels:
         app: user-testing-redis
     spec:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       containers:
         - name: redis
           image: "{{ .Values.image.cloud.userTestingRedis.repository }}:{{ .Values.image.cloud.userTestingRedis.tag }}"

--- a/charts/cloud/templates/user-testing-server-deployment.yaml
+++ b/charts/cloud/templates/user-testing-server-deployment.yaml
@@ -17,10 +17,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/user-testing-db-secret.yaml") . | sha256sum }}
     spec:
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.imagePullSecrets | toYaml | nindent 8 }}

--- a/charts/cloud/templates/web-deployment.yaml
+++ b/charts/cloud/templates/web-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: ent-cloud-web
     spec:
+      {{- include "cloud.computeScheduling" . | nindent 6 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- .Values.imagePullSecrets | toYaml | nindent 8 }}

--- a/charts/cloud/values.yaml
+++ b/charts/cloud/values.yaml
@@ -1,4 +1,18 @@
 nodeSelector: &nodeSelector {}
+# Top-level affinity / tolerations (applied where referenced).
+affinity: {}
+tolerations: []
+
+# Compute-tier scheduling for stateless workloads (api, web, nginx, user-testing,
+# analytics). Falls back to the top-level nodeSelector/affinity/tolerations when
+# unset, so existing consumers are unaffected. Stateful DB workloads are NOT
+# steered by this and keep using the top-level nodeSelector, so they stay on
+# default (on-demand) capacity unless the top-level nodeSelector is set.
+compute:
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 podAnnotations:
   app: protopie
 


### PR DESCRIPTION
## What
Adds an opt-in `compute.{nodeSelector,affinity,tolerations}` values block plus a `cloud.computeScheduling` helper, used by the stateless workloads (api, web, nginx, user-testing server/redis/legacy, analytics). DB workloads (db, user-testing-db) are intentionally **not** steered and keep using the top-level `nodeSelector`.

## Why
Lets staging `-ee` environments run compute on the Karpenter **spot** NodePool while databases stay on **on-demand** (the spot pool is taint-protected; DB pods carry no spot toleration).

## Backward compatibility
`compute.*` falls back to the top-level `nodeSelector/affinity/tolerations` when unset. Verified with `helm template`: with no overrides, **no** scheduling fields are emitted on any workload — identical to current output. Other consumers (enterprise-eks via `main`) are unaffected.

## Verification
- `helm lint` clean.
- Rendered with a representative `-ee` values + spot overlay: compute → `capacity-type=spot` + spot toleration; `db`/`user-testing-db` → no nodeSelector, no spot toleration.
- Legacy UT path (`useLegacy=true`) also renders correctly.

Targets `internal` (staging lineage). Consumed by staging-eks PR (pins bumped to this change's commit; f4-ee tracks `internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)