### PR TITLE
feat(honmoon): add chart for the Enterprise License Admin

### DIFF
--- a/charts/honmoon/Chart.yaml
+++ b/charts/honmoon/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: honmoon
+description: A Helm chart for honmoon (Enterprise License Admin)
+
+type: application
+
+version: 0.1.0
+
+appVersion: "1.0.0"

--- a/charts/honmoon/templates/api-deployment.yaml
+++ b/charts/honmoon/templates/api-deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: api
+    app.kubernetes.io/part-of: enterprise-license-admin
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      {{- with .Values.nodeSelector }}
+      # The dev honmoon images are built linux/arm64 ONLY (honmoon
+      # .github/workflows/deploy-dev-app.yaml runs on a native arm64 runner —
+      # the previous QEMU multi-arch build took 10+ min cold). staging is a MIXED
+      # amd64 + arm64 fleet, so without this pin the scheduler can place the pod
+      # on an amd64 node and the container dies with `exec format error`.
+      # Drop this only together with restoring an amd64 image variant.
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: api-sa
+      # The api image runs as non-root appuser (uid/gid 1001). fsGroup makes the
+      # mounted secret volumes (CA + Google SA) group-owned by 1001 so 0440 files
+      # are readable by the process — without it, 0400 root-owned files give EACCES.
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: api
+          image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
+          imagePullPolicy: {{ .Values.image.api.pullPolicy }}
+          ports:
+            - containerPort: 3100
+          envFrom:
+            - configMapRef:
+                name: honmoon-config
+            - secretRef:
+                name: honmoon-secret
+          env:
+            # License-signing CA — mounted as files from honmoon-secret
+            # (PROTOPIE_CA_CERT/KEY synced from SSM). honmoon reads these PATHs;
+            # the signing key defaults to the CA key (same file).
+            - name: PROTOPIE_CA_CERT_PATH
+              value: /etc/protopie-ca/protopie.crt
+            - name: PROTOPIE_CA_KEY_PATH
+              value: /etc/protopie-ca/protopie.key
+            - name: PROTOPIE_SIGNING_KEY_PATH
+              value: /etc/protopie-ca/protopie.key
+            # Google Workspace SA key — mounted as a file from honmoon-secret
+            # (GOOGLE_SA_KEY_JSON synced from SSM). honmoon reads this PATH for the
+            # Account Manager directory lookup; GOOGLE_WORKSPACE_DOMAIN/ADMIN_EMAIL
+            # arrive via envFrom (honmoon-secret).
+            - name: GOOGLE_SA_KEY_FILE
+              value: /etc/google-sa/sa.json
+            # Salesforce Connected App RSA key — mounted as a file from
+            # honmoon-secret (SF_SA_KEY_PEM synced from SSM). honmoon reads
+            # this PATH at assertion-build time (readFileSync, not cached);
+            # SF_LOGIN_URL/SF_CONSUMER_KEY/SF_INTEGRATION_USERNAME arrive via
+            # envFrom (honmoon-secret).
+            - name: SF_SA_KEY_FILE
+              value: /etc/sf-sa/sf-sa-key.pem
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3100
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3100
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: protopie-ca
+              mountPath: /etc/protopie-ca
+              readOnly: true
+            - name: google-sa
+              mountPath: /etc/google-sa
+              readOnly: true
+            - name: sf-sa
+              mountPath: /etc/sf-sa
+              readOnly: true
+      volumes:
+        - name: protopie-ca
+          secret:
+            secretName: honmoon-secret
+            defaultMode: 288
+            items:
+              - key: PROTOPIE_CA_CERT
+                path: protopie.crt
+              - key: PROTOPIE_CA_KEY
+                path: protopie.key
+        - name: google-sa
+          secret:
+            secretName: honmoon-secret
+            defaultMode: 288
+            items:
+              - key: GOOGLE_SA_KEY_JSON
+                path: sa.json
+        - name: sf-sa
+          secret:
+            secretName: honmoon-sf-key
+            # Runbook (sf-sync-deployment.md §2) asks for 0400 owned by
+            # appuser(1001); 0440 mirrors the working google-sa mount so the
+            # non-root container can actually read it. Tighten to 0400 +
+            # fsGroup once verified in-cluster.
+            defaultMode: 288
+            items:
+              - key: SF_SA_KEY_PEM
+                path: sf-sa-key.pem

--- a/charts/honmoon/templates/api-service-account.yaml
+++ b/charts/honmoon/templates/api-service-account.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api-sa
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: api
+    app.kubernetes.io/part-of: enterprise-license-admin
+  annotations:
+    # IRSA role for the api pod. Its trust policy is bound to this cluster's OIDC
+    # provider + this SA (system:serviceaccount:<ns>:api-sa) and grants
+    # s3:PutObject on the license-artifact bucket — a pod-scoped least-privilege
+    # role instead of the node role.
+    eks.amazonaws.com/role-arn: {{ .Values.api.serviceAccount.roleArn }}

--- a/charts/honmoon/templates/api-service.yaml
+++ b/charts/honmoon/templates/api-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: api
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 3100
+      targetPort: 3100
+      protocol: TCP

--- a/charts/honmoon/templates/configmap.yaml
+++ b/charts/honmoon/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: honmoon-config
+  namespace: {{ .Values.namespace }}
+data:
+  {{- toYaml .Values.config | nindent 2 }}

--- a/charts/honmoon/templates/external-secret.yaml
+++ b/charts/honmoon/templates/external-secret.yaml
@@ -1,0 +1,48 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: honmoon-secret
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.storeName }}
+    kind: ClusterSecretStore
+  target:
+    name: honmoon-secret
+    creationPolicy: Owner
+  data:
+    # Every key is pulled from <ssmPrefix>/<KEY>; the SSM parameter name and the
+    # Secret key are always identical, so values.yaml lists names only.
+    # ⚠️ One missing SSM parameter fails the WHOLE ExternalSecret sync — register
+    # a key in SSM before adding it here.
+    {{- range .Values.externalSecrets.keys }}
+    - secretKey: {{ . }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.ssmPrefix }}/{{ . }}
+    {{- end }}
+---
+# Salesforce Connected App private key — DELIBERATELY a separate Secret, not a
+# honmoon-secret key (honmoon PR #247 review, security hard-veto): honmoon-secret
+# is envFrom-injected into the api Deployment, so a PEM key there would land in
+# every container's process environment (/proc/*/environ, crash dumps) despite
+# only ever being needed as a mounted FILE. This Secret is referenced ONLY by
+# the sf-sa volumes (api-deployment + sf-sync-cronjob); never add it to any
+# envFrom.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: honmoon-sf-key
+  namespace: {{ .Values.namespace }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.storeName }}
+    kind: ClusterSecretStore
+  target:
+    name: honmoon-sf-key
+    creationPolicy: Owner
+  data:
+    - secretKey: SF_SA_KEY_PEM
+      remoteRef:
+        key: {{ .Values.externalSecrets.ssmPrefix }}/SF_SA_KEY_PEM

--- a/charts/honmoon/templates/ingress.yaml
+++ b/charts/honmoon/templates/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: honmoon-ingress
+  namespace: {{ .Values.namespace }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 3100
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web
+                port:
+                  number: 80

--- a/charts/honmoon/templates/namespace.yaml
+++ b/charts/honmoon/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/part-of: enterprise-license-admin

--- a/charts/honmoon/templates/sf-sync-cronjob.yaml
+++ b/charts/honmoon/templates/sf-sync-cronjob.yaml
@@ -1,0 +1,96 @@
+# Hourly Salesforce → DB account/opportunity mirror sync.
+#
+# Same api image, command overridden to the SF sync entrypoint
+# (apps/api/dist/salesforce-sync/sf-main.js) — no separate image. The manual
+# dashboard "Sync now" button runs the same syncSalesforce() in-process in the
+# API and is NOT gated; ENABLE_SF_SYNC below gates only this automated path,
+# which is why the gate lives HERE and not in honmoon-config (see honmoon
+# docs/runbooks/sf-sync-deployment.md §3).
+#
+# Least-privilege shape (honmoon PR #247 review, security hard-veto): NO envFrom
+# — the aggregate honmoon-secret carries CA signing keys, GitHub App keys, ArgoCD
+# tokens and Slack/Okta credentials this job has no business holding, so only
+# the DB + SF keys are injected individually. The PEM comes from the dedicated
+# honmoon-sf-key Secret as a FILE only, and the ServiceAccount is the
+# IRSA-less sf-sync-sa (no AWS permissions).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: honmoon-sf-sync
+  namespace: {{ .Values.namespace }}
+spec:
+  schedule: {{ .Values.sfSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 0 # app-level behavior is skip-and-log; no K8s-level retry storms
+      template:
+        spec:
+          restartPolicy: Never
+          {{- with .Values.nodeSelector }}
+          # Runs the honmoon-api image, which is arm64-only on dev — see
+          # api-deployment.yaml.
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: sf-sync-sa # IRSA-less — sync needs no AWS access
+          securityContext:
+            fsGroup: 1001 # image runs as appuser(1001); without this the 0440 root-owned PEM is unreadable (EACCES every run)
+          containers:
+            - name: sf-sync
+              image: "{{ .Values.image.api.repository }}:{{ .Values.image.api.tag }}"
+              # api-latest is a MUTABLE tag (not ":latest", so the default
+              # policy is IfNotPresent) — without Always a node could keep
+              # running a stale cached image every hour. Matches the aws-cost
+              # CronJob precedent.
+              imagePullPolicy: {{ .Values.image.api.pullPolicy }}
+              command: ["sh", "-c"]
+              args:
+                - >
+                  export DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT:-5432}/${DB_NAME}?schema=${DB_SCHEMA:-public}" &&
+                  node apps/api/dist/salesforce-sync/sf-main.js
+              env:
+                # DB connection — individual keys, never envFrom (see header).
+                - name: DB_HOST
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_HOST } }
+                - name: DB_PORT
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_PORT } }
+                - name: DB_USER
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_USER } }
+                - name: DB_PASSWORD
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_PASSWORD } }
+                - name: DB_NAME
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_NAME } }
+                - name: DB_SCHEMA
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: DB_SCHEMA } }
+                # Salesforce Connected App (JWT Bearer) — auth trio; the RSA
+                # key arrives as a FILE below, never as an env value.
+                - name: SF_LOGIN_URL
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: SF_LOGIN_URL } }
+                - name: SF_CONSUMER_KEY
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: SF_CONSUMER_KEY } }
+                - name: SF_INTEGRATION_USERNAME
+                  valueFrom: { secretKeyRef: { name: honmoon-secret, key: SF_INTEGRATION_USERNAME } }
+                - name: SF_SA_KEY_FILE
+                  value: /etc/sf-sa/sf-sa-key.pem
+                # Gate must be explicitly on for the cron path — sf-main.ts
+                # logs and exits 0 without it. Deliberately set here, not in
+                # honmoon-config (runbook §3).
+                - name: ENABLE_SF_SYNC
+                  value: "true"
+              volumeMounts:
+                - name: sf-sa
+                  mountPath: /etc/sf-sa
+                  readOnly: true
+              resources:
+                {{- toYaml .Values.sfSync.resources | nindent 16 }}
+          volumes:
+            - name: sf-sa
+              secret:
+                secretName: honmoon-sf-key # dedicated PEM Secret — never in any envFrom
+                defaultMode: 288 # 0440 octal; readable via fsGroup 1001 above
+                items:
+                  - key: SF_SA_KEY_PEM
+                    path: sf-sa-key.pem

--- a/charts/honmoon/templates/sf-sync-service-account.yaml
+++ b/charts/honmoon/templates/sf-sync-service-account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sf-sync-sa
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: sf-sync
+    app.kubernetes.io/part-of: enterprise-license-admin
+  # DELIBERATELY no IRSA annotation (honmoon PR #247 review): the SF->DB sync
+  # touches only Salesforce REST + PostgreSQL — no AWS APIs — so reusing api-sa
+  # would hand a workload that parses external Salesforce data an unneeded
+  # s3:PutObject grant on the license-artifact bucket.

--- a/charts/honmoon/templates/web-deployment.yaml
+++ b/charts/honmoon/templates/web-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web
+    app.kubernetes.io/part-of: enterprise-license-admin
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      {{- with .Values.nodeSelector }}
+      # arm64-only image on a mixed-arch staging fleet — see api-deployment.yaml.
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}

--- a/charts/honmoon/templates/web-service.yaml
+++ b/charts/honmoon/templates/web-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: web
+spec:
+  selector:
+    app: web
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP

--- a/charts/honmoon/values.yaml
+++ b/charts/honmoon/values.yaml
@@ -1,0 +1,77 @@
+# Defaults for the honmoon chart. Every environment-specific value lives in the
+# consuming repo's values file (staging-eks: dev-honmoon/honmoon.values.yaml) —
+# nothing here should be env-specific, so a missing override fails loudly rather
+# than silently deploying dev settings somewhere else.
+
+# Namespace every resource is pinned to, and the Namespace object this chart
+# creates. Set explicitly instead of relying on the release namespace so the
+# rendered output is identical no matter how helm/argocd is invoked.
+namespace: honmoon
+
+# Applied to api, web and the sf-sync CronJob. Empty = no constraint.
+# staging pins arm64 because the dev images are built arm64-only.
+nodeSelector: {}
+
+image:
+  # `tag` carries the digest too, e.g. `api-latest@sha256:...` — that is the
+  # shape argocd-image-updater writes under `update-strategy: digest`, and the
+  # templates render "<repository>:<tag>" (a tag is ignored when a digest is
+  # present). api and web MUST stay separate values paths: they share one ECR
+  # repository, and image-updater collides on shared image names when the two
+  # targets are not independently addressable (that collision is exactly why
+  # this chart replaced the kustomize overlay).
+  api:
+    repository: ""
+    tag: ""
+    pullPolicy: Always
+  web:
+    repository: ""
+    tag: ""
+    pullPolicy: Always
+
+api:
+  replicas: 1
+  serviceAccount:
+    # IRSA role granting s3:PutObject on the license-artifact bucket.
+    roleArn: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+web:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+ingress:
+  className: nginx
+  host: ""
+
+sfSync:
+  schedule: "0 * * * *"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+externalSecrets:
+  refreshInterval: 1h
+  storeName: aws-parameter-store
+  # SSM path prefix; each key below is pulled from <ssmPrefix>/<KEY>.
+  ssmPrefix: ""
+  keys: []
+
+# ConfigMap `honmoon-config` contents, injected wholesale via envFrom.
+config: {}


### PR DESCRIPTION
dev-honmoon의 kustomize 오버레이(staging-eks)를 차트로 **1:1 이식**했습니다.

## 왜 helm인가 — Helm이 좋아서가 아니라 image-updater 때문입니다

honmoon은 **api와 web이 ECR 저장소 하나(`honmoon`)를 태그로만 구분**합니다. argocd-image-updater의 **kustomize 경로는 레지스트리+레포로 대상을 식별**합니다:

- 현재 태그 조회: `ContainsImage(img, false)` — 두 번째 인자 `false`가 "태그 비교하지 마라"
- 쓰기: `SetKustomizeImage`도 같은 방식으로 엔트리를 찾음

그래서 두 alias가 **같은 엔트리로 수렴하고 한쪽이 다른 쪽을 덮어씁니다.** 살아남는 건 항상 `honmoon-web`이고, api digest는 **08-07 · 08-12 · 08-13 세 번 손으로** 박아야 했습니다. `siem`도 완전히 같은 형태·같은 증상입니다.

write-back을 `git`→`argocd`로 바꿔도(staging-eks#282) 그대로였는데, 그게 **방식이 원인이 아니었다는 증거**입니다.

**helm 경로는 쓰기 대상을 `<alias>.helm.image-name` / `image-tag` 어노테이션에서 가져옵니다.** 그래서 한 레포에 alias 둘이어도 각자 주소를 갖습니다 — dev-ee / f1-ee / f3-ee / qa-ee가 `enterprise-cloud` 레포를 공유하면서도 멀쩡한 이유입니다.

> upstream 수정 [argoproj-labs/argocd-image-updater#1763](https://github.com/argoproj-labs/argocd-image-updater/pull/1763)이 2026-08-10에 머지됐지만 **아직 어떤 릴리스에도 없습니다** (최신 v1.2.2 / 2026-06-25, 우리는 v0.18.0). 대안이던 ECR 레포 분리와 저울질한 결과입니다.

## 검증 — 렌더 결과 완전 일치

```
helm template  vs  kubectl kustomize  →  12 리소스, 불일치 0건
```

리소스별로 정규화 JSON 비교했습니다. Namespace / ServiceAccount×2 / ConfigMap / Service×2 / Deployment×2 / CronJob / ExternalSecret×2 / Ingress 전부입니다.

ConfigMap 35개 키와 ExternalSecret 30개 키는 손으로 옮기지 않고 **기존 렌더 결과에서 기계적으로 추출**했습니다 (SSM prefix 일치도 30/30 확인).

## 환경별 값은 이 레포에 두지 않았습니다

차트는 구조적 기본값만 갖고, dev 네임스페이스·호스트·IRSA 롤·SSM prefix·ConfigMap 내용은 전부 `staging-eks/dev-honmoon/honmoon.values.yaml`에 있습니다.

## 머지 순서

이 PR이 **먼저** 머지돼야 합니다. staging-eks PR이 차트를 커밋 SHA로 핀하므로, 머지 후 그 SHA로 갱신해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)