### PR TITLE
feat(cloud): route /_AMapService to connect-server (AMap secure proxy)

### DIFF
--- a/charts/cloud/templates/nginx-deployment.yaml
+++ b/charts/cloud/templates/nginx-deployment.yaml
@@ -237,6 +237,22 @@ data:
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
+
+        # connect-cloud-server: AMap (高德) JS API secure proxy.
+        # The AMap SDK hard-codes this prefix at the domain root — it cannot be
+        # moved under /api/connect or renamed — so it needs its own location
+        # instead of riding on an existing connect prefix. Without it the
+        # catch-all `location /` sends these to web_server, which 404s.
+        # No trailing slash + proxy_pass without URI → path passed through
+        # unrewritten, i.e. connect-server serves /_AMapService/* at its root
+        # (same layer the /api/connect/ block strips down to).
+        location ^~ /_AMapService {
+            proxy_pass http://connect_cloud_server;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
         {{- end }}
 
         {{- if .Values.analytics.enabled }}

--- a/charts/cloud/templates/nginx-deployment.yaml
+++ b/charts/cloud/templates/nginx-deployment.yaml
@@ -40,7 +40,15 @@ data:
       include /etc/nginx/virtualhost/virtualhost.conf;
     }
 
-  virtualhost.conf: |
+  virtualhost.conf: |{{ include "cloud.nginx.virtualhost" . }}
+{{- /*
+  The body below is wrapped in a define purely so the Deployment can hash the
+  *rendered* conf (checksum/nginx-conf). It used to hash a hand-picked list of
+  values instead, so a routing change in this template produced no annotation
+  change — nginx pods kept serving the old conf until someone ran
+  `kubectl rollout restart` by hand. Content and indentation are unchanged.
+*/}}
+{{- define "cloud.nginx.virtualhost" }}
     upstream web_server {
       server ent-cloud-web-svc.{{ .Release.Namespace }}.svc.cluster.local;
     }
@@ -305,6 +313,7 @@ data:
     }
 
     {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -357,7 +366,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/nginx-conf: {{ printf "%s%s%s%s%s%s" (.Values.cloud.host | toString) (.Values.cloud.api.featureFlag | toString) (.Values.userTesting | toYaml) (.Values.analytics | toYaml) (.Values.cloud.share | toYaml) (.Values.connect | toYaml) | sha256sum }}
+        # Hash the rendered virtualhost.conf, not the values it happens to read.
+        # Any change to the routing template now rolls nginx on its own.
+        checksum/nginx-conf: {{ include "cloud.nginx.virtualhost" . | sha256sum }}
       labels:
         app: nginx
     spec:


### PR DESCRIPTION
## 왜

Map Navigation 의 AMap(高德) provider 추가 요청 건. AMap JS API 의 보안 프록시는 `/_AMapService` 를 **도메인 root 의 고정 prefix** 로 요구한다 — `/api/connect/_AMapService` 처럼 다른 경로 아래로 옮기거나 이름을 바꿀 수 없다.

현재 `virtualhost.conf` 에 `/_AMapService` 전용 location 이 없어서 catch-all `location /` 이 이 요청들을 `web_server`(cloud-web) 로 보내고 404 가 난다.

## 무엇

**1. `^~ /_AMapService` location 추가** — 기존 `connect.enabled` 게이트 안, `/connect` 블록 바로 뒤.

`proxy_pass http://connect_cloud_server;` (URI 없음 = rewrite 없음) 이므로 경로가 그대로 넘어간다. 즉 **connect-server 가 `/_AMapService/*` 를 자기 root 에서 서빙한다**는 전제다 — `/api/connect/` 블록이 스트립해서 도달하는 것과 같은 계층.

> ⚠️ **앱팀 확인 요청**: 만약 이 엔드포인트를 Next.js route handler(basePath=`/connect`)로 구현하신다면 upstream 경로가 `/connect/_AMapService` 가 되어야 합니다. 그 경우 `proxy_pass http://connect_cloud_server/connect/_AMapService;` 한 줄만 바꾸면 되니 알려주세요. (현재 ProtoPie org 전체 코드검색에 `_AMapService` 구현체가 아직 없어 root 로 가정했습니다.)

**2. `checksum/nginx-conf` 가 렌더된 conf 를 해싱하도록 수정**

기존 체크섬은 values 몇 개(`cloud.host`, `api.featureFlag`, `userTesting`, `analytics`, `cloud.share`, `connect`)만 해싱했다. 라우팅 템플릿만 고치면 이 값들이 안 변하니 **어노테이션이 그대로 → nginx 파드가 롤아웃되지 않고 옛 conf 를 계속 서빙**한다. 위 1번 변경도 정확히 여기에 걸린다.

`virtualhost.conf` 본문을 define 으로 감싸고(내용·들여쓰기 무변경) 렌더 결과를 해싱하도록 바꿨다. 이 커밋만 따로 드롭하셔도 되지만, 그러면 배포 후 `kubectl rollout restart deploy/nginx -n {f1-ee,f3-ee}` 가 수동으로 필요하다.

## 검증

- `helm lint charts/cloud` — pass
- **렌더 diff**: f1-ee / f3-ee / 기본 values 3종 모두, 추가된 location 블록과 체크섬 값 외에 **바이트 동일**. `connect.enabled=false`(prod enterprise-eks 경로)는 체크섬 값만 바뀐다.
- **`nginx -t`**: f1-ee 렌더 결과를 `nginx:1.29-alpine` 컨테이너에 마운트 → `syntax is ok / test is successful`
- **실제 라우팅 테스트**: 위 conf 로 nginx 를 띄우고 upstream 을 stub 서버로 대체해 확인

  | 요청 | 도달 upstream | 전달된 경로 |
  |---|---|---|
  | `/_AMapService/v3/vectormap` | connect-server:3033 | `/_AMapService/v3/vectormap` |
  | `/_AMapService/v4/map/styles` | connect-server:3033 | `/_AMapService/v4/map/styles` |
  | `/connect/engines/x.js` | connect-server:3033 | `/connect/engines/x.js` (기존과 동일) |
  | `/api/connect/foo` | connect-server:3033 | `/foo` (기존과 동일) |
  | `/api/v3/ping` | api_server | `/ping` (기존과 동일) |
  | `/some/page` | web_server | `/some/page` (기존과 동일) |

## 배포

f1-ee / f3-ee 는 이 브랜치의 커밋을 ArgoCD `targetRevision` 으로 직접 pin 한다. pin 갱신 PR: https://github.com/ProtoPie/staging-eks/pull/301

connect 스택은 KEDA dependency-wake 대상이 아니라 상시 1 replica 이므로 scale-to-zero 기상 이슈는 없다.