### PR TITLE
fix(cloud): forward the LB's X-Forwarded-Proto, not $scheme

### DIFF
--- a/charts/cloud/templates/nginx-deployment.yaml
+++ b/charts/cloud/templates/nginx-deployment.yaml
@@ -134,6 +134,18 @@ data:
         '' close;
     }
 
+    # TLS terminates at the load balancer and this server only ever listens on
+    # 80, so $scheme is always "http". Forwarding that as X-Forwarded-Proto tells
+    # upstreams the request was plaintext, and anything that builds an absolute
+    # URL from the request protocol then hands an http:// link back to a browser
+    # sitting on an https page (connect-server's AMap serviceUrl did exactly
+    # this). Prefer what the load balancer reported; fall back to $scheme only
+    # when the header is absent, i.e. direct in-cluster calls.
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $http_x_forwarded_proto;
+        '' $scheme;
+    }
+
     server {
         listen 80;
         # redirect to web
@@ -196,7 +208,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
         }
 
         # User Testing Server - REST API endpoint
@@ -205,7 +217,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Forwarded-Prefix /api/ut;
         }
         {{- end }}
@@ -220,7 +232,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_read_timeout 86400s;
             proxy_send_timeout 86400s;
         }
@@ -231,7 +243,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Forwarded-Prefix /api/connect;
         }
 
@@ -243,7 +255,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
         }
 
         # connect-cloud-server: AMap (高德) JS API secure proxy.
@@ -259,7 +271,7 @@ data:
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
         }
         {{- end }}
 


### PR DESCRIPTION
## 증상

f1-ee의 AMap(高德) 보안 프록시 요청이 `https://f1-ee.protopie.works/_AMapService/...` 대신 **`http://`** 로 나갑니다. https 페이지의 http 서브리소스라 브라우저가 mixed content로 차단하고, 설령 나가더라도 ALB의 :80은 SG상 staging NAT 2개(`44.239.115.231/32`, `44.227.7.200/32`)만 허용이라 타임아웃입니다. 실제로 nginx 액세스 로그에 `_AMapService` 유입이 **0건**입니다.

라우팅 자체는 정상입니다 — `curl https://f1-ee.protopie.works/_AMapService/v4/map/styles?key=test` → `403 {"error":"Forbidden","message":"Runtime proxy capability is invalid"}` (웹 404가 아니라 connect-server가 직접 응답).

## 원인

1. TLS는 ALB에서 끝나고 이 server 블록은 `listen 80`뿐 → **`$scheme`은 항상 `http`**
2. 그런데 6개 location 전부 `proxy_set_header X-Forwarded-Proto $scheme;` → ALB가 준 `https`를 `http`로 덮어씀
3. connect-server는 `PPC_TRUST_PROXY=true`라 이 헤더를 신뢰 → `request.protocol` = `http`
4. `@ppc/server` `server/modules/engine-layers.js`가 그 값으로 AMap serviceUrl을 만듦:
   ```js
   serviceOrigin: new URL(`${request.protocol}://${request.headers.host ?? request.hostname}`).origin,
   ```
   → `EngineConnectorService.js`에서 `serviceUrl`로 조립되어 클라이언트로 내려감
5. 웹 클라이언트에 origin 교정 헬퍼가 있지만 `if(!e||"local"!==n)return e;` — **local 모드 전용**이라 cloud에선 서버 값 그대로 사용

## 변경

ALB가 보고한 proto를 우선 쓰고, 헤더가 없을 때만 `$scheme`으로 폴백하는 map을 추가했습니다. 헤더가 없는 클러스터 내부 직접 호출은 **기존과 동일**하게 동작합니다(무회귀).

AMap뿐 아니라 같은 결함을 가진 `/api/ut`, `/api/connect`, `/connect` location도 함께 교정했습니다.

## 검증

- 렌더 diff = map 블록 + 헤더 6줄 + `checksum/nginx-conf` 변경뿐 (체크섬이 바뀌어야 nginx 파드가 새 conf를 집습니다 — 0c8fde9에서 고친 부분)
- `nginx -t` 통과 (모든 토글 ON으로 렌더한 실제 conf, nginx:1.26.3-alpine)
- map 동작 실측: 헤더 `https` → `https` / 헤더 `http` → `http` / **헤더 없음 → `$scheme`(기존 동작)**

## 남은 것

- Chart.yaml 버전은 안 올렸습니다. PR#19과 동일하게 staging이 SHA로 pin하는 피처 브랜치라서, 버전 bump는 internal/main으로 올릴 때 함께 하는 게 맞다고 봅니다.
- 머지 후 f1-ee/f3-ee pin 갱신 PR이 따라붙습니다 (staging-eks).
- 배포 후 최종 확인: nginx 로그의 `_AMapService` 유입이 0건 → https 200으로 바뀌는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)